### PR TITLE
Feature/grunt watch

### DIFF
--- a/bsp-grunt.js
+++ b/bsp-grunt.js
@@ -162,6 +162,7 @@ module.exports = function(grunt, config) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-less');
   grunt.loadNpmTasks('grunt-contrib-requirejs');
+  grunt.loadNpmTasks('grunt-contrib-watch');
 
   grunt.task.registerTask('bsp-config-dest', 'Configure build destination.', function() {
     if (!grunt.config('bsp.maven.destDir')) {

--- a/bsp-grunt.js
+++ b/bsp-grunt.js
@@ -79,6 +79,28 @@ module.exports = function(grunt, config) {
         ]
       },
 
+      compiledCSS: {
+        files: [
+          {
+            cwd: '<%= bsp.styles.compiledLessDir %>',
+            dest: '<%= bsp.styles.minDir %>',
+            expand: true,
+            src: '**/*<%= bsp.styles.ext %>'
+          }
+        ]
+      },
+
+      compiledCSSForWatcher: {
+        files: [
+          {
+            cwd: '<%= bsp.styles.compiledLessDir %>',
+            dest: '<%= bsp.styles.srcDir %>',
+            expand: true,
+            src: '**/*<%= bsp.styles.ext %>'
+          }
+        ]
+      },
+
       less: {
         files: {
           '<%= bsp.scripts.devDir %>/less.js':
@@ -86,6 +108,12 @@ module.exports = function(grunt, config) {
               grunt.file.readJSON('node_modules/grunt-contrib-less/node_modules/less/bower.json')['main']
         }
       }
+    },
+
+    clean: {
+      sourceCSS: [
+        '<%= bsp.styles.srcDir %>' + '**/*<%= bsp.styles.ext %>'
+      ]
     },
 
     less: {
@@ -108,19 +136,6 @@ module.exports = function(grunt, config) {
       }
     },
 
-    autoprefixer: {
-      process: {
-        files: [
-          {
-            cwd: '<%= bsp.styles.compiledLessDir %>',
-            dest: '<%= bsp.styles.minDir %>',
-            expand: true,
-            src: '**/*<%= bsp.styles.ext %>'
-          }
-        ]
-      }
-    },
-
     requirejs: {
       dynamic: {
         options: {
@@ -132,36 +147,18 @@ module.exports = function(grunt, config) {
       }
     },
 
-    browserify: {
-      autoprefixer: {
-        files: [
-          {
-            dest: '<%= bsp.scripts.devDir %>/less-dev.js',
-            src: 'node_modules/grunt-autoprefixer/node_modules/autoprefixer/lib/autoprefixer.js'
-          }
-        ],
 
-        options: {
-          bundleOptions: {
-            standalone: 'autoprefixer'
-          },
-
-          postBundleCB: function(err, src, next) {
-            src += 'window.less = window.less || { };';
-            src += 'window.less.env = "development";';
-            src += 'window.less.postProcessor = function(css) { return autoprefixer(';
-            src += _.map(grunt.config('autoprefixer.process.options.browsers') || [ ], function(browser) { return '"' + browser + '"'; }).join(', ');
-            src += ').process(css).css; };';
-            next(err, src);
-          }
-        }
+    watch: {
+      less: {
+        files: '<%= bsp.styles.srcDir %>' + '/**/*.less',
+        tasks: ['bsp-config-dest', 'less:compile', 'copy:compiledCSSForWatcher']
       }
     }
+
   }, (config || { })));
 
-  grunt.loadNpmTasks('grunt-autoprefixer');
   grunt.loadNpmTasks('grunt-bower-install-simple');
-  grunt.loadNpmTasks('grunt-browserify');
+  grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-less');
   grunt.loadNpmTasks('grunt-contrib-requirejs');
@@ -286,7 +283,8 @@ module.exports = function(grunt, config) {
   });
 
   grunt.registerTask('bsp', [
-    'bsp-config-dest',
+    'bsp-config-dest', // configure the destination that maven creates
+    'clean:sourceCSS', // clean up the source directories of any compiled CSS that were copied there by a watcher
     'bsp-config-requirejs',
     'bower-prune',
     'bower-install-simple:all',
@@ -295,14 +293,14 @@ module.exports = function(grunt, config) {
     'copy:bower',
     'copy:styles',
     'less:compile',
-    'autoprefixer:process',
     'copy:scripts',
     'requirejs:dynamic',
-    'copy:less',
-    'browserify:autoprefixer'
+    'copy:less', // this copies less.js to allow for client side compilation
+    'copy:compiledCSS' // copies the compiled CSS to the target dir, this was the task performed by the autoprefixed before we removed it
   ]);
 
   grunt.registerTask('default', [
     'bsp'
   ]);
+
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "grunt-autoprefixer": "~0.7.3",
     "grunt-bower-install-simple": "~1.0.3",
     "grunt-browserify": "~2.1.0",
+    "grunt-contrib-clean"   : "~0.5.0",
     "grunt-cli": "~0.1.13",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-less": "~0.11.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-less": "~0.11.0",
     "grunt-contrib-requirejs": "~0.4.3",
+    "grunt-contrib-watch"   : "~0.5.3",
     "requirejs": "~2.1.11"
   },
   "repository": {


### PR DESCRIPTION
1) removed browserify and autoprefixer

2) added compiledCSS copy task to move compiled LESS files to the target minified directory

3) added compiledCSSForWatcher task which copies the compiled LESS back to src directory for fast local development. This allows for dev to used a compiled file vs client side LESS

4) added grunt watcher task, which watches for LESS changes and runs the compiledCSSForWatcher copy task

5) added a clean task to the default grunt task which cleans up the src directory if a full build/grunt is run