### PR TITLE
Add detection of environment variables to affect build process

### DIFF
--- a/.example-env
+++ b/.example-env
@@ -1,0 +1,3 @@
+# Using this file as a template, create an `.env` file at the root of your project to set environment specific variables for node.
+
+MODE = development

--- a/bsp-grunt.js
+++ b/bsp-grunt.js
@@ -1,3 +1,6 @@
+// Load environment specific variables (fails silently)
+require('dotenv').config({silent: true});
+
 module.exports = function(grunt, config) {
     var EXTEND = require('extend');
     var Builder = require('systemjs-builder');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsp-grunt",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Standard set of Grunt configurations for Brightspot projects.",
   "keywords": [
     "brightspot",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "autoprefixer": "6.1.0",
     "babel-core": "5.6.20",
     "bower": "1.6.5",
+    "dotenv": "^2.0.0",
     "es6-module-loader": "0.17.8",
     "extend": "3.0.0",
     "grunt-bower-install-simple": "1.1.4",

--- a/tasks/system.js
+++ b/tasks/system.js
@@ -6,6 +6,12 @@ module.exports = function(grunt) {
     grunt.registerMultiTask('systemjs', 'Compiles systemjs apps', function() {
         var bspGruntDir = path.resolve(__dirname, '..');
 
+        var envConfigOverrides = {};
+        if (process.env.MODE === "development"){
+            envConfigOverrides.minify = false;
+            envConfigOverrides.sourceMaps = false;
+        }
+
         var config = {
             minify: true,
             polyfills: true,
@@ -22,9 +28,16 @@ module.exports = function(grunt) {
         var done = this.async();
         var options = this.options();
 
+        // environment specific config should trump the default config
+        config = _.extend({}, config, envConfigOverrides);
+
+        // the project gruntfile's config trumps all previous configs
         if (options.configOverrides) {
-            config = _.extend({}, config, options.configOverrides);
+            config = _.extend(config, options.configOverrides);
         }
+
+        grunt.log.ok("SystemJs configured with:");
+        console.dir(config);
 
         this.files.forEach(function(file) {
             filesCount++;


### PR DESCRIPTION
It would be nice to have a way changing the pipeline and options of the build process depending on the environment that its being run. 

This update provides a way for the code to read variables from the local node processes environment and then conditionally updates the Grunt build. Currently, this code supports the detection of a "mode" variable, that, when set to "development" will leave the javascript source code un-minified and skip generating a source-map. This fixes the issue during development we could no longer rely on setting breakpoints in the devtools or using the `debugger` keyword to manually set breakpoints in code. In the future, this could be extended to the build script/Beam to generate `.env` files for various deploy contexts.

By default the mode is production, so change the mode you'll need to create a `.env` file at the root of your project and refer to the `.example-env` file. For further information, refer to this module: https://www.npmjs.com/package/dotenv